### PR TITLE
Add support for custom guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ return [
 
 You can enable or disable specific documents by setting the `enabled` flag to `true` or `false`.
 
+You can also add custom documents by setting the `custom` flag to `true`.
+When this flag is set, the command will not copy the file to the output path, but it will include it in the index.md if such a file exists in the output path.
+
 ## Usage
 
 After installing the package, you can:

--- a/src/Console/Commands/InstallGuidelinesCommand.php
+++ b/src/Console/Commands/InstallGuidelinesCommand.php
@@ -114,6 +114,11 @@ class InstallGuidelinesCommand extends Command
 
         // Copy selected documents
         foreach ($documents as $document => $install) {
+            if ($configDocuments[$document]['custom'] ?? false) {
+                $this->line("Skipped custom <info>{$configDocuments[$document]['name']}</info>");
+                continue;
+            }
+
             if ($install && isset($configDocuments[$document]) && ($configDocuments[$document]['enabled'] ?? false)) {
                 $documentPath = $configDocuments[$document]['path'] ?? $document.'.md';
                 $source = __DIR__.'/../../docs/'.$documentPath;
@@ -139,6 +144,12 @@ class InstallGuidelinesCommand extends Command
                 $documentConfig = $configDocuments[$document];
                 $title = $documentConfig['name'];
                 $path = $documentConfig['path'] ?? $document.'.md';
+
+                if (! File::exists(base_path($outputPath.'/'.$path))) {
+                    $this->warn("Document <info>{$title}</info> not found at {$path}.");
+                    continue;
+                }
+
                 $content .= "- [{$title}]({$path})\n";
             }
         }


### PR DESCRIPTION
This PR adds support for custom guidelines.
It allows to include files already present in the output directory.
Guidelines marked with `'custom' => true` will not be copied from the vendor directory to the output directory, but will be included in the index.md

Additionally it can be used to mark modified guidelines, to prevent them from being overwritten, when running install again.